### PR TITLE
Fix gradlew path in all steps

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       #Authorizing gradlew files
       - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        run: chmod +x sdk/gradlew
 
       #Build project
       - name: Build with Gradle
@@ -29,7 +29,7 @@ jobs:
           base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
 
       - name: Publish package
-        run: ./gradlew publishToSonatype closeAndReleaseStagingRepository -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=${{secrets.SIGNING_KEY_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg) -Dorg.gradle.internal.http.socketTimeout=300000 --stacktrace
+        run: ./sdk/gradlew publishToSonatype closeAndReleaseStagingRepository -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=${{secrets.SIGNING_KEY_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg) -Dorg.gradle.internal.http.socketTimeout=300000 --stacktrace
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
All the gradle files and build tools are in the sdk folder, rather than the main one. This should fix the building actions